### PR TITLE
Add keywords to space.f1nn.chorus.desktop

### DIFF
--- a/data/space.f1nn.chorus.desktop
+++ b/data/space.f1nn.chorus.desktop
@@ -6,4 +6,5 @@ Exec=chorus
 Icon=space.f1nn.chorus
 Terminal=false
 Categories=Audio;Music;
+Keywords=lyrics;music;audio;song;mpris;karaoke;
 StartupNotify=true


### PR DESCRIPTION
Chorus is not found in Gnome search when I type "lyrics". Keywords are needed.